### PR TITLE
Enforce that ids are unique in all ICEPhys tables

### DIFF
--- a/src/pynwb/ndx_icephys_meta/icephys.py
+++ b/src/pynwb/ndx_icephys_meta/icephys.py
@@ -113,7 +113,7 @@ class IntracellularRecordings(DynamicTable):
                       'stimulus': (stimulus_start_index, stimulus_index_count, stimulus),
                       'response': (response_start_index, response_index_count, response)}
         row_kwargs.update(kwargs)
-        return super(IntracellularRecordings, self).add_row(**row_kwargs)
+        return super(IntracellularRecordings, self).add_row(enforce_unique_id=True, **row_kwargs)
 
 
 @register_class('Sweeps', namespace)
@@ -171,7 +171,7 @@ class Sweeps(DynamicTable):
         recordings = getargs('recordings', kwargs)
         if recordings is None:
             kwargs['recordings'] = []
-        re = super(Sweeps, self).add_row(**kwargs)
+        re = super(Sweeps, self).add_row(enforce_unique_id=True, **kwargs)
         return re
 
 
@@ -232,7 +232,7 @@ class SweepSequences(DynamicTable):
         sweeps = getargs('sweeps', kwargs)
         if sweeps is None:
             kwargs['sweeps'] = []
-        re = super(SweepSequences, self).add_row(**kwargs)
+        re = super(SweepSequences, self).add_row(enforce_unique_id=True, **kwargs)
         return re
 
 
@@ -291,7 +291,7 @@ class Runs(DynamicTable):
         sweep_sequences = getargs('sweep_sequences', kwargs)
         if sweep_sequences is None:
             kwargs['sweep_sequences'] = []
-        re = super(Runs, self).add_row(**kwargs)
+        re = super(Runs, self).add_row(enforce_unique_id=True, **kwargs)
         return re
 
 
@@ -346,7 +346,7 @@ class Conditions(DynamicTable):
         runs = getargs('runs', kwargs)
         if runs is None:
             kwargs['runs'] = []
-        re = super(Conditions, self).add_row(**kwargs)
+        re = super(Conditions, self).add_row(enforce_unique_id=True, **kwargs)
         return re
 
 

--- a/src/pynwb/ndx_icephys_meta/test/test_icephys.py
+++ b/src/pynwb/ndx_icephys_meta/test/test_icephys.py
@@ -248,6 +248,21 @@ class IntracellularRecordingsTests(ICEphysMetaTestBase):
                              stimulus=None,
                              response=None)
 
+    def test_enforce_unique_id(self):
+        """
+        Test to ensure that unique ids are enforced on Runs table
+        """
+        ir = IntracellularRecordings()
+        ir.add_recording(electrode=self.electrode,
+                         stimulus=self.stimulus,
+                         response=self.response,
+                         id=10)
+        with self.assertRaises(ValueError):
+            ir.add_recording(electrode=self.electrode,
+                             stimulus=self.stimulus,
+                             response=self.response,
+                             id=10)
+
 
 class SweepsTests(ICEphysMetaTestBase):
     """
@@ -283,6 +298,20 @@ class SweepsTests(ICEphysMetaTestBase):
         sw = Sweeps(intracellular_recordings_table=ir)
         sw.add_sweep(recordings=[0])
         self.write_test_helper(ir=ir, sw=sw)
+
+    def test_enforce_unique_id(self):
+        """
+        Test to ensure that unique ids are enforced on Runs table
+        """
+        ir = IntracellularRecordings()
+        ir.add_recording(electrode=self.electrode,
+                         stimulus=self.stimulus,
+                         response=self.response,
+                         id=10)
+        sw = Sweeps(intracellular_recordings_table=ir)
+        sw.add_sweep(recordings=[0], id=10)
+        with self.assertRaises(ValueError):
+            sw.add_sweep(recordings=[0], id=10)
 
 
 class SweepSequencesTests(ICEphysMetaTestBase):
@@ -322,6 +351,22 @@ class SweepSequencesTests(ICEphysMetaTestBase):
         sws = SweepSequences(sw)
         sws.add_sweep_sequence(sweeps=[0, ])
         self.write_test_helper(ir=ir, sw=sw, sws=sws)
+
+    def test_enforce_unique_id(self):
+        """
+        Test to ensure that unique ids are enforced on Runs table
+        """
+        ir = IntracellularRecordings()
+        ir.add_recording(electrode=self.electrode,
+                         stimulus=self.stimulus,
+                         response=self.response,
+                         id=10)
+        sw = Sweeps(intracellular_recordings_table=ir)
+        sw.add_sweep(recordings=[0])
+        sws = SweepSequences(sw)
+        sws.add_sweep_sequence(sweeps=[0, ], id=10)
+        with self.assertRaises(ValueError):
+            sws.add_sweep_sequence(sweeps=[0, ], id=10)
 
 
 class RunsTests(ICEphysMetaTestBase):
@@ -364,6 +409,24 @@ class RunsTests(ICEphysMetaTestBase):
         runs = Runs(sweep_sequences_table=sws)
         runs.add_run(sweep_sequences=[0, ])
         self.write_test_helper(ir=ir, sw=sw, sws=sws, runs=runs)
+
+    def test_enforce_unique_id(self):
+        """
+        Test to ensure that unique ids are enforced on Runs table
+        """
+        ir = IntracellularRecordings()
+        ir.add_recording(electrode=self.electrode,
+                         stimulus=self.stimulus,
+                         response=self.response,
+                         id=10)
+        sw = Sweeps(intracellular_recordings_table=ir)
+        sw.add_sweep(recordings=[0])
+        sws = SweepSequences(sw)
+        sws.add_sweep_sequence(sweeps=[0, ])
+        runs = Runs(sweep_sequences_table=sws)
+        runs.add_run(sweep_sequences=[0, ], id=10)
+        with self.assertRaises(ValueError):
+            runs.add_run(sweep_sequences=[0, ], id=10)
 
 
 class ConditionsTests(ICEphysMetaTestBase):
@@ -409,6 +472,26 @@ class ConditionsTests(ICEphysMetaTestBase):
         cond = Conditions(runs_table=runs)
         cond.add_condition(runs=[0, ])
         self.write_test_helper(ir=ir, sw=sw, sws=sws, runs=runs, cond=cond)
+
+    def test_enforce_unique_id(self):
+        """
+        Test to ensure that unique ids are enforced on Runs table
+        """
+        ir = IntracellularRecordings()
+        ir.add_recording(electrode=self.electrode,
+                         stimulus=self.stimulus,
+                         response=self.response,
+                         id=10)
+        sw = Sweeps(intracellular_recordings_table=ir)
+        sw.add_sweep(recordings=[0])
+        sws = SweepSequences(sw)
+        sws.add_sweep_sequence(sweeps=[0, ])
+        runs = Runs(sweep_sequences_table=sws)
+        runs.add_run(sweep_sequences=[0, ])
+        cond = Conditions(runs_table=runs)
+        cond.add_condition(runs=[0, ], id=10)
+        with self.assertRaises(ValueError):
+            cond.add_condition(runs=[0, ], id=10)
 
 
 class ICEphysFileTests(ICEphysMetaTestBase):


### PR DESCRIPTION
Fix #8 Add enforce_unique_id flag in all add_row calls and add corresponding unit test for all new table types.