### PR TITLE
import DT and DTR from pynwb instead of hdmf

### DIFF
--- a/src/pynwb/ndx_icephys_meta/icephys.py
+++ b/src/pynwb/ndx_icephys_meta/icephys.py
@@ -2,7 +2,7 @@ from pynwb import register_class
 from pynwb.file import NWBFile
 from pynwb.icephys import IntracellularElectrode
 from pynwb.base import TimeSeries
-from hdmf.common import DynamicTable, DynamicTableRegion
+from pynwb.core import DynamicTable, DynamicTableRegion
 from hdmf.utils import docval, popargs, getargs, call_docval_func, get_docval, fmt_docval_args
 import warnings
 import pandas as pd


### PR DESCRIPTION
This will make your code compatible with earlier versions of pynwb that are still being used by Allen Institute repos like ipfx and AllenSDK

depends on https://github.com/NeurodataWithoutBorders/pynwb/pull/1187