### PR TITLE
Enable use of stimulus template

### DIFF
--- a/src/pynwb/ndx_icephys_meta/icephys.py
+++ b/src/pynwb/ndx_icephys_meta/icephys.py
@@ -637,6 +637,23 @@ class ICEphysFile(NWBFile):
                               DeprecationWarning)
             self._update_sweep_table(timeseries)
 
+    @docval(*get_docval(NWBFile.add_stimulus),
+            {'name': 'use_sweep_table', 'type': bool, 'default': False, 'doc': 'Use the deprecated SweepTable'})
+    def add_stimulus_template(self, **kwargs):
+        """
+        Overwrite behavior from NWBFile to avoid use of the deprecated SweepTable
+        """
+        timeseries = popargs('timeseries', kwargs)
+        self._add_stimulus_template_internal(timeseries)
+        use_sweep_table = popargs('use_sweep_table', kwargs)
+        if use_sweep_table:
+            if self.sweep_table is None:
+                warnings.warn("Use of SweepTable is deprecated. Use the IntracellularRecordings, "
+                              "Sweeps tables instead. See the add_intracellular_recordings, "
+                              "add_sweep, add_sweep_sequence, add_run, add_ic_condition functions.",
+                              DeprecationWarning)
+            self._update_sweep_table(timeseries)
+
     @docval(*get_docval(NWBFile.add_acquisition),
             {'name': 'use_sweep_table', 'type': bool, 'default': False, 'doc': 'Use the deprecated SweepTable'})
     def add_acquisition(self, **kwargs):
@@ -679,7 +696,9 @@ class ICEphysFile(NWBFile):
         """
         # Add the stimulus, response, and electrode to the file if they don't exist yet
         stimulus, response, electrode = getargs('stimulus', 'response', 'electrode', kwargs)
-        if stimulus is not None and stimulus.name not in self.stimulus:
+        if (stimulus is not None and
+                (stimulus.name not in self.stimulus and
+                 stimulus.name not in self.stimulus_template)):
             self.add_stimulus(stimulus, use_sweep_table=False)
         if response is not None and response.name not in self.acquisition:
             self.add_acquisition(response, use_sweep_table=False)

--- a/src/pynwb/ndx_icephys_meta/test/test_icephys.py
+++ b/src/pynwb/ndx_icephys_meta/test/test_icephys.py
@@ -422,6 +422,53 @@ class IntracellularRecordingsTests(ICEphysMetaTestBase):
         self.assertEqual(row_index, 0)
         self.write_test_helper(ir=ir)
 
+    def test_write_with_stimulus_template(self):
+        """
+        Populate, write, and read the Sweeps container and other required containers
+        """
+        local_nwbfile = ICEphysFile(
+                session_description='my first synthetic recording',
+                identifier='EXAMPLE_ID',
+                session_start_time=datetime.now(tzlocal()),
+                experimenter='Dr. Bilbo Baggins',
+                lab='Bag End Laboratory',
+                institution='University of Middle Earth at the Shire',
+                experiment_description='I went on an adventure with thirteen dwarves to reclaim vast treasures.',
+                session_id='LONELYMTN')
+        # Add a device
+        local_device = local_nwbfile.create_device(name='Heka ITC-1600')
+        local_electrode = local_nwbfile.create_ic_electrode(
+            name="elec0",
+            description='a mock intracellular electrode',
+            device=local_device)
+        local_stimulus = VoltageClampStimulusSeries(name="ccss",
+                                                    data=[1, 2, 3, 4, 5],
+                                                    starting_time=123.6,
+                                                    rate=10e3,
+                                                    electrode=local_electrode,
+                                                    gain=0.02,
+                                                    sweep_number=np.uint64(15))
+        local_response = VoltageClampSeries(name='vcs',
+                                            data=[0.1, 0.2, 0.3, 0.4, 0.5],
+                                            conversion=1e-12,
+                                            resolution=np.nan,
+                                            starting_time=123.6,
+                                            rate=20e3,
+                                            electrode=local_electrode,
+                                            gain=0.02,
+                                            capacitance_slow=100e-12,
+                                            resistance_comp_correction=70.0,
+                                            sweep_number=np.uint64(15))
+        local_nwbfile.add_stimulus_template(local_stimulus)
+        row_index = local_nwbfile.add_intracellular_recording(electrode=local_electrode,
+                                                              stimulus=local_stimulus,
+                                                              response=local_response,
+                                                              id=np.int64(10))
+        self.assertEqual(row_index, 0)
+        # Write our test file
+        with NWBHDF5IO(self.path, 'w') as io:
+            io.write(local_nwbfile)
+
 
 class SweepsTests(ICEphysMetaTestBase):
     """


### PR DESCRIPTION
Fix #18 

* Add missing overwrite for NWBFile.add_stimulus_template
* update checks in NWBFile.add_intracellular_recording to also check for stimulus template
* Add test to check that using a stimulus template in the intracellular_recordings table works