### PR TITLE
Add documentation for defining time slices in intracellular_recordings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ response = VoltageClampSeries(
             resistance_comp_correction=70.0)
 
 # (A) Add an intracellular recording to the file
+#     NOTE: We can optionally define time-ranges for the stimulus/response via
+#     the corresponding option _start_index and _index_count parameters.
+#     NOTE: It is allowed to add a recording with just a stimulus or a response
+#     NOTE: We can  add custom columns to any of our tables in steps (A)-(E)
 ir_index = nwbfile.add_intracellular_recording(electrode=electrode,
                                                stimulus=stimulus,
                                                response=response)
@@ -109,7 +113,7 @@ ir_index = nwbfile.add_intracellular_recording(electrode=electrode,
 sweep_index = nwbfile.add_ic_sweep(recordings=[ir_index, ])
 
 # (C) Add a list of sweep table indices as a sweep sequence
-sequence_index = nwbfile.add_ic_sweep_sequence(sweeps=[sweep_index, ])
+sequence_index = nwbfile.add_ic_sweep_sequence(sweeps=[sweep_index, ], stimulus_type='square')
 
 # (D) Add a list of sweep sequence table indices as a run
 run_index = nwbfile.add_ic_run(sweep_sequences=[sequence_index, ])

--- a/src/pynwb/examples/icephys_meta_simple_example.ipynb
+++ b/src/pynwb/examples/icephys_meta_simple_example.ipynb
@@ -159,8 +159,6 @@
    "source": [
     "**Note:** Any time we add a row to one of our tables, the corresponding add function returns the integer index of the newly created row. The rowindex is used in subsequent tables that reference rows in our table.\n",
     "\n",
-    "**Note:** A recording may optionally also consist of just an electrode and stimulus or electrode and response, but at least one of stimulus or response are required.\n",
-    "\n",
     "**Note:** If the ``id`` is omitted then PyNWB will automatically number recordings in sequences (i.e., id is the same as the row number).\n",
     "\n",
     "**Note:** The IntracellularRecordings table is optional and will be created automatically by ICEphysFile the first time the table is being modified. \n",
@@ -197,6 +195,54 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "**Note** We may optionaly also specify the relevant time range for a stimulus and/or response as part of the intracellular_recording. This is useful, e.g., in case where the recording of the stimulus and response do not align (e.g., in case that recording o the response started before the recording of the stimulus)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rowindex2 = nwbfile.add_intracellular_recording(electrode=electrode,\n",
+    "                                                stimulus=stimulus,\n",
+    "                                                stimulus_start_index=1,\n",
+    "                                                stimulus_index_count=3,\n",
+    "                                                response=response,\n",
+    "                                                response_start_index=2,\n",
+    "                                                response_index_count=3,\n",
+    "                                                id=11)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note:** A recording may optionally also consist of just an ``electrode`` and ``stimulus`` or ``electrode`` and ``response``, but at least one of ``stimulus`` or ``response`` are required. If either ``stimulus`` or ``response`` are missing, then the ``stimulus`` and ``response`` are internally set ot the same ``TimeSeries`` and the ``start_index`` and ``index_count`` for the missing parameter are set to ``-1``."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rowindex3 = nwbfile.add_intracellular_recording(electrode=electrode,\n",
+    "                                                response=response,\n",
+    "                                                id=12)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**WARNING** For brevity we reused in the above example the same ``response`` and ``stimulus`` in all rows of the ``intracellular_recordings``. While this is allowed, in most practical cases the ``stimulus`` and ``response`` will change between ``intracellular_recordings``."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### 3.2 Add a sweep\n",
     "\n",
     "Before adding a sweep in Section 3.2.2, we'll take a brief discource to illustrate how we can add custom columns to tables before (see Section 3.2.1) and after (see Section 3.2.3) we have populated the table with data. "
@@ -213,7 +259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -237,7 +283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -288,11 +334,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
-    "rowindex = nwbfile.add_icephys_sweep(recordings=[rowindex], id=12, sweep_tag='LabTag1')"
+    "rowindex = nwbfile.add_icephys_sweep(recordings=[rowindex, rowindex2, rowindex3], \n",
+    "                                     id=12, \n",
+    "                                     sweep_tag='LabTag1')"
    ]
   },
   {
@@ -306,7 +354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -340,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -357,7 +405,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +439,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -407,7 +455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -426,7 +474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -468,6 +516,18 @@
        "      <td>(0, 5, vcs pynwb.icephys.VoltageClampSeries at...</td>\n",
        "      <td>elec0 pynwb.icephys.IntracellularElectrode at ...</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>(1, 3, ccss pynwb.icephys.VoltageClampStimulus...</td>\n",
+       "      <td>(2, 3, vcs pynwb.icephys.VoltageClampSeries at...</td>\n",
+       "      <td>elec0 pynwb.icephys.IntracellularElectrode at ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>(-1, -1, vcs pynwb.icephys.VoltageClampSeries ...</td>\n",
+       "      <td>(0, 5, vcs pynwb.icephys.VoltageClampSeries at...</td>\n",
+       "      <td>elec0 pynwb.icephys.IntracellularElectrode at ...</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
@@ -476,17 +536,23 @@
        "                                             stimulus  \\\n",
        "id                                                      \n",
        "10  (0, 5, ccss pynwb.icephys.VoltageClampStimulus...   \n",
+       "11  (1, 3, ccss pynwb.icephys.VoltageClampStimulus...   \n",
+       "12  (-1, -1, vcs pynwb.icephys.VoltageClampSeries ...   \n",
        "\n",
        "                                             response  \\\n",
        "id                                                      \n",
        "10  (0, 5, vcs pynwb.icephys.VoltageClampSeries at...   \n",
+       "11  (2, 3, vcs pynwb.icephys.VoltageClampSeries at...   \n",
+       "12  (0, 5, vcs pynwb.icephys.VoltageClampSeries at...   \n",
        "\n",
        "                                            electrode  \n",
        "id                                                     \n",
-       "10  elec0 pynwb.icephys.IntracellularElectrode at ...  "
+       "10  elec0 pynwb.icephys.IntracellularElectrode at ...  \n",
+       "11  elec0 pynwb.icephys.IntracellularElectrode at ...  \n",
+       "12  elec0 pynwb.icephys.IntracellularElectrode at ...  "
       ]
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -497,7 +563,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -549,7 +615,7 @@
        "12                                               s...   LabTag1  SweepType1"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -560,7 +626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -609,7 +675,7 @@
        "15                                             rec...        square"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -620,7 +686,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -666,7 +732,7 @@
        "17                                                ..."
       ]
      },
-     "execution_count": 20,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -677,7 +743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -732,7 +798,7 @@
        "21                                        sweep_se...    3"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -750,14 +816,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "conditions ndx_icephys_meta.icephys.Conditions at 0x4603098064\n",
+      "conditions ndx_icephys_meta.icephys.Conditions at 0x4891326288\n",
       "Fields:\n",
       "  colnames: ['runs' 'tag']\n",
       "  columns: (\n",
@@ -786,7 +852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -798,7 +864,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -818,7 +884,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -867,6 +933,18 @@
        "      <td>(0, 5, vcs pynwb.icephys.VoltageClampSeries at...</td>\n",
        "      <td>elec0 pynwb.icephys.IntracellularElectrode at ...</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>(1, 3, ccss pynwb.icephys.VoltageClampStimulus...</td>\n",
+       "      <td>(2, 3, vcs pynwb.icephys.VoltageClampSeries at...</td>\n",
+       "      <td>elec0 pynwb.icephys.IntracellularElectrode at ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>(-1, -1, vcs pynwb.icephys.VoltageClampSeries ...</td>\n",
+       "      <td>(0, 5, vcs pynwb.icephys.VoltageClampSeries at...</td>\n",
+       "      <td>elec0 pynwb.icephys.IntracellularElectrode at ...</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
@@ -875,14 +953,20 @@
        "                                             stimulus  \\\n",
        "id                                                      \n",
        "10  (0, 5, ccss pynwb.icephys.VoltageClampStimulus...   \n",
+       "11  (1, 3, ccss pynwb.icephys.VoltageClampStimulus...   \n",
+       "12  (-1, -1, vcs pynwb.icephys.VoltageClampSeries ...   \n",
        "\n",
        "                                             response  \\\n",
        "id                                                      \n",
        "10  (0, 5, vcs pynwb.icephys.VoltageClampSeries at...   \n",
+       "11  (2, 3, vcs pynwb.icephys.VoltageClampSeries at...   \n",
+       "12  (0, 5, vcs pynwb.icephys.VoltageClampSeries at...   \n",
        "\n",
        "                                            electrode  \n",
        "id                                                     \n",
-       "10  elec0 pynwb.icephys.IntracellularElectrode at ...  "
+       "10  elec0 pynwb.icephys.IntracellularElectrode at ...  \n",
+       "11  elec0 pynwb.icephys.IntracellularElectrode at ...  \n",
+       "12  elec0 pynwb.icephys.IntracellularElectrode at ...  "
       ]
      },
      "metadata": {},
@@ -1190,13 +1274,13 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>19</th>\n",
-       "      <th>0</th>\n",
-       "      <th>17</th>\n",
-       "      <th>15</th>\n",
-       "      <th>square</th>\n",
-       "      <th>12</th>\n",
-       "      <th>LabTag1</th>\n",
+       "      <th rowspan=\"3\" valign=\"top\">19</th>\n",
+       "      <th rowspan=\"3\" valign=\"top\">0</th>\n",
+       "      <th rowspan=\"3\" valign=\"top\">17</th>\n",
+       "      <th rowspan=\"3\" valign=\"top\">15</th>\n",
+       "      <th rowspan=\"3\" valign=\"top\">square</th>\n",
+       "      <th rowspan=\"3\" valign=\"top\">12</th>\n",
+       "      <th rowspan=\"3\" valign=\"top\">LabTag1</th>\n",
        "      <th>SweepType1</th>\n",
        "      <td>10</td>\n",
        "      <td>[0, 5, ccss pynwb.icephys.VoltageClampStimulus...</td>\n",
@@ -1204,16 +1288,44 @@
        "      <td>elec0 pynwb.icephys.IntracellularElectrode at ...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>21</th>\n",
-       "      <th>3</th>\n",
-       "      <th>17</th>\n",
-       "      <th>15</th>\n",
-       "      <th>square</th>\n",
-       "      <th>12</th>\n",
-       "      <th>LabTag1</th>\n",
+       "      <th>SweepType1</th>\n",
+       "      <td>11</td>\n",
+       "      <td>[1, 3, ccss pynwb.icephys.VoltageClampStimulus...</td>\n",
+       "      <td>[2, 3, vcs pynwb.icephys.VoltageClampSeries at...</td>\n",
+       "      <td>elec0 pynwb.icephys.IntracellularElectrode at ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SweepType1</th>\n",
+       "      <td>12</td>\n",
+       "      <td>[-1, -1, vcs pynwb.icephys.VoltageClampSeries ...</td>\n",
+       "      <td>[0, 5, vcs pynwb.icephys.VoltageClampSeries at...</td>\n",
+       "      <td>elec0 pynwb.icephys.IntracellularElectrode at ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"3\" valign=\"top\">21</th>\n",
+       "      <th rowspan=\"3\" valign=\"top\">3</th>\n",
+       "      <th rowspan=\"3\" valign=\"top\">17</th>\n",
+       "      <th rowspan=\"3\" valign=\"top\">15</th>\n",
+       "      <th rowspan=\"3\" valign=\"top\">square</th>\n",
+       "      <th rowspan=\"3\" valign=\"top\">12</th>\n",
+       "      <th rowspan=\"3\" valign=\"top\">LabTag1</th>\n",
        "      <th>SweepType1</th>\n",
        "      <td>10</td>\n",
        "      <td>[0, 5, ccss pynwb.icephys.VoltageClampStimulus...</td>\n",
+       "      <td>[0, 5, vcs pynwb.icephys.VoltageClampSeries at...</td>\n",
+       "      <td>elec0 pynwb.icephys.IntracellularElectrode at ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SweepType1</th>\n",
+       "      <td>11</td>\n",
+       "      <td>[1, 3, ccss pynwb.icephys.VoltageClampStimulus...</td>\n",
+       "      <td>[2, 3, vcs pynwb.icephys.VoltageClampSeries at...</td>\n",
+       "      <td>elec0 pynwb.icephys.IntracellularElectrode at ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SweepType1</th>\n",
+       "      <td>12</td>\n",
+       "      <td>[-1, -1, vcs pynwb.icephys.VoltageClampSeries ...</td>\n",
        "      <td>[0, 5, vcs pynwb.icephys.VoltageClampSeries at...</td>\n",
        "      <td>elec0 pynwb.icephys.IntracellularElectrode at ...</td>\n",
        "    </tr>\n",
@@ -1226,25 +1338,41 @@
        "label                                                                                                                                                    id   \n",
        "conditions_id conditions_tag runs_id sweep_sequences_id sweep_sequences_stimulus_type sweeps_id sweeps_sweep_tag sweeps_sweep_type                            \n",
        "19            0              17      15                 square                        12        LabTag1          SweepType1                              10   \n",
+       "                                                                                                                 SweepType1                              11   \n",
+       "                                                                                                                 SweepType1                              12   \n",
        "21            3              17      15                 square                        12        LabTag1          SweepType1                              10   \n",
+       "                                                                                                                 SweepType1                              11   \n",
+       "                                                                                                                 SweepType1                              12   \n",
        "\n",
        "source_table                                                                                                                                                                           \\\n",
        "label                                                                                                                                                                        stimulus   \n",
        "conditions_id conditions_tag runs_id sweep_sequences_id sweep_sequences_stimulus_type sweeps_id sweeps_sweep_tag sweeps_sweep_type                                                      \n",
        "19            0              17      15                 square                        12        LabTag1          SweepType1         [0, 5, ccss pynwb.icephys.VoltageClampStimulus...   \n",
+       "                                                                                                                 SweepType1         [1, 3, ccss pynwb.icephys.VoltageClampStimulus...   \n",
+       "                                                                                                                 SweepType1         [-1, -1, vcs pynwb.icephys.VoltageClampSeries ...   \n",
        "21            3              17      15                 square                        12        LabTag1          SweepType1         [0, 5, ccss pynwb.icephys.VoltageClampStimulus...   \n",
+       "                                                                                                                 SweepType1         [1, 3, ccss pynwb.icephys.VoltageClampStimulus...   \n",
+       "                                                                                                                 SweepType1         [-1, -1, vcs pynwb.icephys.VoltageClampSeries ...   \n",
        "\n",
        "source_table                                                                                                                                                                           \\\n",
        "label                                                                                                                                                                        response   \n",
        "conditions_id conditions_tag runs_id sweep_sequences_id sweep_sequences_stimulus_type sweeps_id sweeps_sweep_tag sweeps_sweep_type                                                      \n",
        "19            0              17      15                 square                        12        LabTag1          SweepType1         [0, 5, vcs pynwb.icephys.VoltageClampSeries at...   \n",
+       "                                                                                                                 SweepType1         [2, 3, vcs pynwb.icephys.VoltageClampSeries at...   \n",
+       "                                                                                                                 SweepType1         [0, 5, vcs pynwb.icephys.VoltageClampSeries at...   \n",
        "21            3              17      15                 square                        12        LabTag1          SweepType1         [0, 5, vcs pynwb.icephys.VoltageClampSeries at...   \n",
+       "                                                                                                                 SweepType1         [2, 3, vcs pynwb.icephys.VoltageClampSeries at...   \n",
+       "                                                                                                                 SweepType1         [0, 5, vcs pynwb.icephys.VoltageClampSeries at...   \n",
        "\n",
        "source_table                                                                                                                                                                           \n",
        "label                                                                                                                                                                       electrode  \n",
        "conditions_id conditions_tag runs_id sweep_sequences_id sweep_sequences_stimulus_type sweeps_id sweeps_sweep_tag sweeps_sweep_type                                                     \n",
        "19            0              17      15                 square                        12        LabTag1          SweepType1         elec0 pynwb.icephys.IntracellularElectrode at ...  \n",
-       "21            3              17      15                 square                        12        LabTag1          SweepType1         elec0 pynwb.icephys.IntracellularElectrode at ...  "
+       "                                                                                                                 SweepType1         elec0 pynwb.icephys.IntracellularElectrode at ...  \n",
+       "                                                                                                                 SweepType1         elec0 pynwb.icephys.IntracellularElectrode at ...  \n",
+       "21            3              17      15                 square                        12        LabTag1          SweepType1         elec0 pynwb.icephys.IntracellularElectrode at ...  \n",
+       "                                                                                                                 SweepType1         elec0 pynwb.icephys.IntracellularElectrode at ...  \n",
+       "                                                                                                                 SweepType1         elec0 pynwb.icephys.IntracellularElectrode at ...  "
       ]
      },
      "metadata": {},


### PR DESCRIPTION
Fix #35 

* Updated simple example in README.md to:
    * mention the time slices support
    * mention support for just using a stimulus or response
    * fix missing stimulus_type parameter
* Updated the basic example notebook to show time slicing
* Updated the basic example notebook to show using just a stimulus or response