### PR TITLE
Minor fixes to run readme code using latest HDMF

### DIFF
--- a/src/pynwb/ndx_icephys_meta/icephys.py
+++ b/src/pynwb/ndx_icephys_meta/icephys.py
@@ -291,11 +291,10 @@ class AlignedDynamicTable(DynamicTable):
 
     def __contains__(self, val):
         """
-        Check if the give value (i.e., column) exists in this table
+        Check if the given value (i.e., column) exists in this table
 
-        If the val is a string then check if the given category exists. If val is a tuple
-        of two strings (category, colname) then check for the given category if the given
-        colname exists.
+        :param val: If val is a string then check if the given category exists. If val is a tuple
+        of two strings (category, colname) then check for the given category if the given colname exists.
         """
         if isinstance(val, str):
             return val in self.category_tables or val in self.colnames

--- a/src/pynwb/ndx_icephys_meta/icephys.py
+++ b/src/pynwb/ndx_icephys_meta/icephys.py
@@ -289,7 +289,6 @@ class AlignedDynamicTable(DynamicTable):
         # Set the self.category_tables attribute, which will set the parent/child relationships for the category_tables
         self.category_tables = dts
 
-    @docval({'name': 'val', 'type': (str, tuple), 'doc': 'The name of the category or column to check.'})
     def __contains__(self, val):
         """
         Check if the give value (i.e., column) exists in this table
@@ -304,6 +303,8 @@ class AlignedDynamicTable(DynamicTable):
             if len(val) != 2:
                 raise ValueError("Expected tuple of strings of length 2 got tuple of length %i" % len(val))
             return val[1] in self.get_category(val[0])
+        else:
+            return False
 
     @property
     def categories(self):

--- a/src/pynwb/ndx_icephys_meta/icephys.py
+++ b/src/pynwb/ndx_icephys_meta/icephys.py
@@ -227,7 +227,7 @@ class AlignedDynamicTable(DynamicTable):
     """
     __fields__ = (
         {'name': 'category_tables', 'child': True},
-        'description')
+    )
 
     @docval(*get_docval(DynamicTable.__init__),
             {'name': 'category_tables', 'type': list,


### PR DESCRIPTION
Update `AlignedDynamicTable.__fields__` to not redefine the field `description` inherited from `DynamicTable`. 

`AlignedDynamicTable.__contains__(...)` allows arguments of type str and tuple, but must allow the test condition `None in table`, for example, in https://github.com/hdmf-dev/hdmf/blob/dev/src/hdmf/common/io/table.py#L30

This can be solved by changing docval for `__contains__` to allow NoneType by making 'val' optional (there is no straightforward way to allow NoneType without making it optional) or by removing the docval entirely. I decided to remove the docval because it did not seem necessary to mess with the `in` operator.

Tests are still failing but at least the example in README.md now runs without error. 